### PR TITLE
Merge probing_stats and probing_percent into probing_stat

### DIFF
--- a/av1an-core/src/lib.rs
+++ b/av1an-core/src/lib.rs
@@ -24,7 +24,6 @@ use chunk::Chunk;
 use dashmap::DashMap;
 use once_cell::sync::OnceCell;
 use serde::{Deserialize, Serialize};
-pub use settings::ProbingStats;
 use strum::{Display, EnumString, IntoStaticStr};
 pub use target_quality::VmafFeature;
 
@@ -515,4 +514,30 @@ pub enum ProbingSpeed {
     Fast = 3,
     #[strum(serialize = "veryfast")]
     VeryFast = 4,
+}
+
+#[derive(Serialize, Deserialize, Debug, EnumString, IntoStaticStr, Display, Clone)]
+pub enum ProbingStatisticName {
+    #[strum(serialize = "mean")]
+    Mean = 0,
+    #[strum(serialize = "median")]
+    Median = 1,
+    #[strum(serialize = "harmonic")]
+    Harmonic = 2,
+    #[strum(serialize = "percentile")]
+    Percentile = 3,
+    #[strum(serialize = "standard-deviation")]
+    StandardDeviation = 4,
+    #[strum(serialize = "mode")]
+    Mode = 5,
+    #[strum(serialize = "minimum")]
+    Minimum = 6,
+    #[strum(serialize = "maximum")]
+    Maximum = 7,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct ProbingStatistic {
+    pub name:  ProbingStatisticName,
+    pub value: Option<f64>,
 }

--- a/av1an-core/src/settings.rs
+++ b/av1an-core/src/settings.rs
@@ -44,16 +44,6 @@ pub enum InputPixelFormat {
     FFmpeg { format: Pixel },
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, clap::ValueEnum)]
-pub enum ProbingStats {
-    #[value(name = "mean")]
-    Mean,
-    #[value(name = "median")]
-    Median,
-    #[value(name = "harmonic_mean")]
-    HarmonicMean,
-}
-
 #[allow(clippy::struct_excessive_bools)]
 #[derive(Debug)]
 pub struct EncodeArgs {

--- a/av1an-core/src/vmaf.rs
+++ b/av1an-core/src/vmaf.rs
@@ -1,5 +1,6 @@
 use std::{
     cmp::Ordering,
+    collections::HashMap,
     ffi::OsStr,
     path::Path,
     process::{Command, Stdio},
@@ -10,7 +11,15 @@ use plotters::prelude::*;
 use serde::{Deserialize, Serialize};
 use smallvec::SmallVec;
 
-use crate::{broker::EncoderCrash, ffmpeg, ref_smallvec, util::printable_base10_digits, Input};
+use crate::{
+    broker::EncoderCrash,
+    ffmpeg,
+    ref_smallvec,
+    util::printable_base10_digits,
+    Input,
+    ProbingStatistic,
+    ProbingStatisticName,
+};
 
 #[derive(Deserialize, Serialize, Debug)]
 struct VmafScore {
@@ -27,12 +36,104 @@ struct VmafResult {
     frames: Vec<Metrics>,
 }
 
-#[derive(Debug, Clone, Copy)]
-pub enum VmafScoreMethod {
-    Percentile(f64),
-    Mean,
-    Median,
-    HarmonicMean,
+pub struct MetricStatistics {
+    scores: Vec<f64>,
+    cache:  HashMap<String, f64>,
+}
+
+impl MetricStatistics {
+    pub fn new(scores: Vec<f64>) -> Self {
+        MetricStatistics {
+            scores,
+            cache: HashMap::new(),
+        }
+    }
+
+    fn get_or_compute(&mut self, key: &str, compute: impl FnOnce(&[f64]) -> f64) -> f64 {
+        *self.cache.entry(key.to_string()).or_insert_with(|| compute(&self.scores))
+    }
+
+    pub fn mean(&mut self) -> f64 {
+        self.get_or_compute("average", |scores| {
+            scores.iter().sum::<f64>() / scores.len() as f64
+        })
+    }
+
+    pub fn harmonic_mean(&mut self) -> f64 {
+        self.get_or_compute("harmonic_mean", |scores| {
+            let sum_reciprocals: f64 = scores.iter().map(|&x| 1.0 / x).sum();
+            scores.len() as f64 / sum_reciprocals
+        })
+    }
+
+    pub fn median(&mut self) -> f64 {
+        let mut sorted_scores = self.scores.clone();
+        sorted_scores.sort_by(|a, b| a.partial_cmp(b).unwrap_or(Ordering::Less));
+        self.get_or_compute("median", |scores| {
+            let mid = scores.len() / 2;
+            if scores.len() % 2 == 0 {
+                (sorted_scores[mid - 1] + sorted_scores[mid]) / 2.0
+            } else {
+                sorted_scores[mid]
+            }
+        })
+    }
+
+    pub fn mode(&mut self) -> f64 {
+        let mut counts = HashMap::new();
+        for score in &self.scores {
+            // Round to nearest integer for fewer unique buckets
+            let rounded_score = score.round() as i32;
+            *counts.entry(rounded_score).or_insert(0) += 1;
+        }
+        let max_count = counts.values().copied().max().unwrap_or(0);
+        self.get_or_compute("mode", |scores| {
+            *scores
+                .iter()
+                .find(|score| counts[&(score.round() as i32)] == max_count)
+                .unwrap_or(&0.0)
+        })
+    }
+
+    pub fn minimum(&mut self) -> f64 {
+        self.get_or_compute("minimum", |scores| {
+            *scores.iter().min_by(|a, b| a.partial_cmp(b).unwrap()).unwrap_or(&0.0)
+        })
+    }
+
+    pub fn maximum(&mut self) -> f64 {
+        self.get_or_compute("maximum", |scores| {
+            *scores.iter().max_by(|a, b| a.partial_cmp(b).unwrap()).unwrap_or(&0.0)
+        })
+    }
+
+    pub fn variance(&mut self) -> f64 {
+        let average = self.mean();
+        self.get_or_compute("variance", |scores| {
+            scores
+                .iter()
+                .map(|x| {
+                    let diff = x - average;
+                    diff * diff
+                })
+                .sum::<f64>()
+                / scores.len() as f64
+        })
+    }
+
+    pub fn standard_deviation(&mut self) -> f64 {
+        let variance = self.variance();
+        self.get_or_compute("standard_deviation", |_| variance.sqrt())
+    }
+
+    pub fn percentile(&mut self, index: usize) -> f64 {
+        let mut sorted_scores = self.scores.clone();
+        sorted_scores.sort_by(|a, b| a.partial_cmp(b).unwrap_or(Ordering::Less));
+        self.get_or_compute(&format!("percentile_{index}"), |scores| {
+            let index = (index as f64 / 100.0 * scores.len() as f64) as usize;
+            *sorted_scores.get(index).unwrap_or(&sorted_scores[0])
+        })
+    }
 }
 
 pub fn plot_vmaf_score_file(scores_file: &Path, plot_path: &Path) -> anyhow::Result<()> {
@@ -497,39 +598,40 @@ pub fn read_vmaf_file(file: impl AsRef<Path>) -> Result<Vec<f64>, serde_json::Er
 /// Read a certain, given percentile VMAF score from the VMAF json file
 pub fn read_weighted_vmaf<P: AsRef<Path>>(
     file: P,
-    method: VmafScoreMethod,
+    probe_statistic: ProbingStatistic,
 ) -> Result<f64, serde_json::Error> {
     let scores = read_vmaf_file(file)?;
     assert!(!scores.is_empty());
 
-    match method {
-        VmafScoreMethod::Percentile(percentile) => {
-            let mut sorted_scores = scores.clone();
-            sorted_scores.sort_by(|a, b| a.partial_cmp(b).unwrap_or(Ordering::Less));
+    // Must be mutable as each computation is cached for reuse in implementation
+    let mut metric_statistics = MetricStatistics::new(scores);
 
-            let index = ((sorted_scores.len() as f64 * percentile) as usize)
-                .saturating_sub(1)
-                .min(sorted_scores.len() - 1);
-
-            Ok(sorted_scores[index])
-        },
-        VmafScoreMethod::Mean => Ok(scores.iter().sum::<f64>() / scores.len() as f64),
-        VmafScoreMethod::Median => {
-            let mut sorted_scores = scores.clone();
-            sorted_scores.sort_by(|a, b| a.partial_cmp(b).unwrap_or(Ordering::Less));
-
-            let len = sorted_scores.len();
-            if len % 2 == 0 {
-                Ok((sorted_scores[len / 2 - 1] + sorted_scores[len / 2]) / 2.0)
+    let statistic = match probe_statistic.name {
+        ProbingStatisticName::Mean => metric_statistics.mean(),
+        ProbingStatisticName::Median => metric_statistics.median(),
+        ProbingStatisticName::Harmonic => metric_statistics.harmonic_mean(),
+        ProbingStatisticName::Percentile => {
+            if let Some(value) = probe_statistic.value {
+                metric_statistics.percentile(value as usize)
             } else {
-                Ok(sorted_scores[len / 2])
+                panic!("Expected a value for Percentile statistic");
             }
         },
-        VmafScoreMethod::HarmonicMean => {
-            let sum_reciprocals: f64 = scores.iter().map(|&x| 1.0 / x).sum();
-            Ok(scores.len() as f64 / sum_reciprocals)
+        ProbingStatisticName::StandardDeviation => {
+            if let Some(value) = probe_statistic.value {
+                let sigma =
+                    metric_statistics.mean() + (value * metric_statistics.standard_deviation());
+                sigma.clamp(metric_statistics.minimum(), metric_statistics.maximum())
+            } else {
+                panic!("Expected a value for StandardDeviation statistic");
+            }
         },
-    }
+        ProbingStatisticName::Mode => metric_statistics.mode(),
+        ProbingStatisticName::Minimum => metric_statistics.minimum(),
+        ProbingStatisticName::Maximum => metric_statistics.maximum(),
+    };
+
+    Ok(statistic)
 }
 
 pub fn percentile_of_sorted(scores: &[f64], percentile: f64) -> f64 {

--- a/site/src/Cli/target_quality.md
+++ b/site/src/Cli/target_quality.md
@@ -6,6 +6,7 @@ Name | Flag | Type | Default
 [Probes](#probes---probes) | `--probes` | Integer | `4`
 [Probing Rate](#probing-rate---probing-rate) | `--probing-rate` | Integer | `1`
 [Probing Speed](#probing-speed---probing-speed) | `--probing-speed` | `PROBING_SPEED` |
+[Probing Statistic](#probing-statistic---probing-statistic) | `--probing-statistic` | String | `percentile-1`
 [Probe Slow](#probe-slow---probe-slow) | `--probe-slow` || 
 [Minimum Quantizer](#minimum-quantizer---min-q) | `--min-q` | Integer | Based on Encoder
 [Maximum Quantizer](#maximum-quantizer---max-q) | `--max-q` | Integer | Based on Encoder
@@ -71,6 +72,34 @@ Can be any of the following:
 ### Default
 
 If not specified, `veryfast` is used unless `--probe-slow` is specified.
+
+## Probing Statistic `--probing-statistic`
+
+Statistical method for calculating target quality from sorted probe results.
+
+### Possible Values
+
+Can be any of the following:
+
+* `mean` - Arithmetic mean (average)
+* `median` - Middle value
+* `harmonic` - Harmonic mean (emphasizes lower scores)
+* `percentile-<FLOAT>` - Percentile of a specified `<FLOAT>` value, where `<FLOAT>` is a value between 0.0 and 100.0
+* `standard-deviation-<FLOAT>` - Standard deviation distance from mean (σ) clamped by the minimum and maximum probe scores of a specified `<FLOAT>` value, where `<FLOAT>` can be a positive or negative value
+* `mode` - Most common integer-rounded value
+* `minimum` - Lowest value
+* `maximum` - Highest value
+
+### Default
+
+If not specified, `percentile-1` is used.
+
+### Examples
+
+* `> av1an -i input.mkv -o output.mkv --target-quality 80 --probing-statistic mean` - Target a VMAF score of 80 using the mean statistic
+* `> av1an -i input.mkv -o output.mkv --target-quality 95 --probing-statistic percentile-25` - Target a VMAF score of 95 using the 25th percentile statistic
+* `> av1an -i input.mkv -o output.mkv --target-quality 90 --probing-statistic standard-deviation--0.8` - Target a VMAF score of 90 using the value that is 0.8 standard deviations below the mean
+* `> av1an -i input.mkv -o output.mkv --target-quality 75 --probing-statistic standard-deviation-2` - Target a VMAF score of 75 using the value that is 2 standard deviations above the mean.
 
 ## Probe Slow `--probe-slow`
 

--- a/site/src/av1an.md
+++ b/site/src/av1an.md
@@ -89,6 +89,7 @@ Name | Flag | Type | Default
 [Probes](./Cli/target_quality.md#probes---probes) | `--probes` | Integer | `4`
 [Probing Rate](./Cli/target_quality.md#probing-rate---probing-rate) | `--probing-rate` | Integer | `1`
 [Probing Speed](./Cli/target_quality.md#probing-speed---probing-speed) | `--probing-speed` | `PROBING_SPEED` |
+[Probing Statistic](./Cli/target_quality.md#probing-statistic---probing-statistic) | `--probing-statistic` | String | `percentile-1`
 [Probe Slow](./Cli/target_quality.md#probe-slow---probe-slow) | `--probe-slow` || 
 [Minimum Quantizer](./Cli/target_quality.md#minimum-quantizer---min-q) | `--min-q` | Integer | Based on Encoder
 [Maximum Quantizer](./Cli/target_quality.md#maximum-quantizer---max-q) | `--max-q` | Integer | Based on Encoder


### PR DESCRIPTION
Add MetricStatistics impl - Originates from PR #988 with a few additions
Remove duplicate VmafScoreMethod Enum
Add probing_stat validation
Add probing_stat documentation

```
      --probing-stat <PROBING_STAT>
          Statistical method for calculating target quality from sorted probe
          scores

          Available methods:
            mean      - Arithmetic mean (average)
            median    - Middle value
            harmonic  - Harmonic mean (emphasizes lower scores)
            percentile-<FLOAT> - Percentile of a specified value. Must be between
          0.0 and 100.0
            standard-deviation-<FLOAT> - Standard deviation distance from mean (σ)
          clamped by the minimum and maximum probe scores
            mode      - Most common integer-rounded value
            minimum   - Lowest value
            maximum   - Highest value

          [default: percentile-1]
```