### PR TITLE
Refactor Target Quality

### DIFF
--- a/av1an-core/src/broker.rs
+++ b/av1an-core/src/broker.rs
@@ -114,6 +114,8 @@ impl Display for EncoderCrash {
 }
 
 impl Broker<'_> {
+    /// Main encoding loop. set_thread_affinity may be ignored if the value is
+    /// invalid.
     #[tracing::instrument(skip(self))]
     pub fn encoding_loop(
         self,
@@ -211,6 +213,7 @@ impl Broker<'_> {
     ) -> Result<(), Option<Box<EncoderCrash>>> {
         let st_time = Instant::now();
 
+        // we display the index, so we need to subtract 1 to get the max index
         let padding = printable_base10_digits(self.chunk_queue.len() - 1) as usize;
         update_mp_chunk(worker_id, chunk.index, padding);
 

--- a/av1an-core/src/lib.rs
+++ b/av1an-core/src/lib.rs
@@ -25,7 +25,7 @@ use dashmap::DashMap;
 use once_cell::sync::OnceCell;
 use serde::{Deserialize, Serialize};
 pub use settings::ProbingStats;
-use strum::{Display, EnumString, IntoStaticStr};
+use strum::{Display, EnumString, FromRepr, IntoStaticStr};
 pub use target_quality::VmafFeature;
 
 use crate::progress_bar::finish_progress_bar;
@@ -503,7 +503,7 @@ fn read_chunk_queue(temp: &Path) -> anyhow::Result<Vec<Chunk>> {
     Ok(serde_json::from_str(&contents)?)
 }
 
-#[derive(Serialize, Deserialize, Debug, EnumString, IntoStaticStr, Display, Clone)]
+#[derive(Serialize, Deserialize, Debug, EnumString, IntoStaticStr, Display, Clone, FromRepr)]
 pub enum ProbingSpeed {
     #[strum(serialize = "veryslow")]
     VerySlow = 0,


### PR DESCRIPTION
Some important comments were restored. Target Quality has been refactored and variables renamed for readability. Comments were added as a starter to demonstrate their utility. Logging has also been fixed and expanded. All possible reasons are now handled and logged correctly. Also the `quantizer_score_history` (formerly `history`) still contained a rogue PathBuf item in the tuple that is never used. This PR fixes that.

`predict_quantizer` (formerly `predict_crf`) has been simplified with very minor optimizations that avoid unused computation. ~~**During testing I have encountered a critical bug that needs to be retested and addressed in the origin repository.**~~ Exception behavior has been commented in refactor. We now also attempt Linear Interpolation when Catmull-Rom fails before finally falling back to binary searching.

Thanks,
\- Boats M.